### PR TITLE
feat: Add PUT /lead/{lead_id} route to modify lead

### DIFF
--- a/domain/contact.py
+++ b/domain/contact.py
@@ -19,6 +19,23 @@ class LeadPayload(BaseModel):
 class LeadRequest(BaseModel):
     lead: LeadPayload
     altcha: str
+    visitorId: Optional[str] = None
+
+class LeadUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    email: Optional[EmailStr] = None
+    phone: Optional[str] = None
+    job_title: Optional[str] = None
+    company_name: Optional[str] = None
+    company_size: Optional[int] = None
+    positions: Optional[List[str]] = None
+    concerns: Optional[List[str]] = None
+    problem_summary: Optional[str] = None
+    estimated_users: Optional[int] = None
+    urgency: Optional[str] = None
+    conscent: Optional[bool] = None
+    altcha: str
+    visitorId: str
 
 class ReportRequest(BaseModel):
     altcha: str

--- a/domain/orm.py
+++ b/domain/orm.py
@@ -70,10 +70,13 @@ class Lead(Base):
     maturity_score = Column(Integer, nullable=True)
     urgency_id = Column(Integer, ForeignKey("lead_urgencies.id"), nullable=True)
     status_id = Column(Integer, ForeignKey("lead_statuses.id"), nullable=False)
+    fingerprint_visitor_id = Column(String, ForeignKey("fingerprints.visitorId"), nullable=True)
+    altcha_solution = Column(String, nullable=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
+    fingerprint = relationship("Fingerprint")
     contact = relationship("Contact", back_populates="leads")
     company = relationship("Company", back_populates="leads")
     status = relationship("LeadStatus")
@@ -84,6 +87,7 @@ class Lead(Base):
     attachments = relationship("LeadAttachment", back_populates="lead")
     history = relationship("LeadHistory", back_populates="lead")
     notes = relationship("Note", back_populates="lead")
+    modification_logs = relationship("LeadModificationLog", back_populates="lead")
 
     @hybrid_property
     def potential_score(self):
@@ -136,6 +140,17 @@ class LeadHistory(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     lead = relationship("Lead", back_populates="history")
+
+class LeadModificationLog(Base):
+    __tablename__ = "lead_modification_logs"
+    id = Column(Integer, primary_key=True)
+    lead_id = Column(Integer, ForeignKey("leads.id"), nullable=False)
+    field_name = Column(String, nullable=False)
+    old_value = Column(String, nullable=True)
+    new_value = Column(String, nullable=True)
+    changed_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    lead = relationship("Lead", back_populates="modification_logs")
 
 class NoteReason(Base):
     __tablename__ = 'note_reasons'

--- a/migrations/alembic/versions/2027b2482496_add_lead_modification_log_table.py
+++ b/migrations/alembic/versions/2027b2482496_add_lead_modification_log_table.py
@@ -1,0 +1,38 @@
+"""add_lead_modification_log_table
+
+Revision ID: 2027b2482496
+Revises: c69042aa4359
+Create Date: 2025-09-02 09:20:08.197000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2027b2482496'
+down_revision: Union[str, Sequence[str], None] = 'c69042aa4359'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'lead_modification_logs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('lead_id', sa.Integer(), nullable=False),
+        sa.Column('field_name', sa.String(), nullable=False),
+        sa.Column('old_value', sa.String(), nullable=True),
+        sa.Column('new_value', sa.String(), nullable=True),
+        sa.Column('changed_at', sa.DateTime(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['lead_id'], ['leads.id'], ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('lead_modification_logs')

--- a/migrations/alembic/versions/501d57f35ae2_add_fingerprint_to_lead.py
+++ b/migrations/alembic/versions/501d57f35ae2_add_fingerprint_to_lead.py
@@ -1,0 +1,36 @@
+"""add_fingerprint_to_lead
+
+Revision ID: 501d57f35ae2
+Revises: 2027b2482496
+Create Date: 2025-09-02 09:24:22.387000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '501d57f35ae2'
+down_revision: Union[str, Sequence[str], None] = '2027b2482496'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('leads', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('fingerprint_visitor_id', sa.String(), nullable=True))
+        batch_op.create_foreign_key(
+            'fk_leads_fingerprint_visitor_id',
+            'fingerprints',
+            ['fingerprint_visitor_id'], ['visitorId']
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('leads', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_leads_fingerprint_visitor_id', type_='foreignkey')
+        batch_op.drop_column('fingerprint_visitor_id')

--- a/migrations/alembic/versions/b0ea83a6aa3e_add_altcha_to_lead.py
+++ b/migrations/alembic/versions/b0ea83a6aa3e_add_altcha_to_lead.py
@@ -1,0 +1,30 @@
+"""add_altcha_to_lead
+
+Revision ID: b0ea83a6aa3e
+Revises: 501d57f35ae2
+Create Date: 2025-09-02 09:31:13.200000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b0ea83a6aa3e'
+down_revision: Union[str, Sequence[str], None] = '501d57f35ae2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('leads', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('altcha_solution', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('leads', schema=None) as batch_op:
+        batch_op.drop_column('altcha_solution')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,84 @@
+import pytest
+from fastapi.testclient import TestClient
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from infrastructure.web.app import app, get_current_user
+from infrastructure.web.auth import oauth2_scheme, TokenData
+from domain.orm import Lead, Contact, Company, Position, Concern, LeadPosition, LeadConcern, LeadUrgency, LeadStatus, NoteReason
+
+# Override the OIDC dependency for testing
+async def override_get_current_user():
+    return TokenData(username="testuser")
+
+async def override_oauth2_scheme():
+    return "fake-token"
+
+app.dependency_overrides[get_current_user] = override_get_current_user
+app.dependency_overrides[oauth2_scheme] = override_oauth2_scheme
+
+@pytest.fixture(scope="session", autouse=True)
+def test_db():
+    from infrastructure.database import Base, engine, SessionLocal
+    from domain.orm import LeadStatus, LeadUrgency, RecommendedPack
+    # Set up the database
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+
+    # Clean up enum tables before seeding
+    db.query(LeadStatus).delete()
+    db.query(LeadUrgency).delete()
+    db.query(RecommendedPack).delete()
+    db.query(NoteReason).delete()
+    db.commit()
+
+    # Seed enum tables
+    db.add_all([
+        NoteReason(name='appel sortant'),
+        NoteReason(name='mail sortant'),
+        NoteReason(name='appel entrant'),
+        NoteReason(name='mail entrant'),
+        NoteReason(name='rencontre'),
+        LeadStatus(name='nouveau'),
+        LeadStatus(name='à rappeler'),
+        LeadStatus(name='relancé'),
+        LeadStatus(name='proposition envoyée'),
+        LeadStatus(name='gagné'),
+        LeadStatus(name='perdu'),
+        LeadUrgency(name='immédiat'),
+        LeadUrgency(name='ce mois'),
+        LeadUrgency(name='moyen terme'),
+        RecommendedPack(name='conformité'),
+        RecommendedPack(name='confiance'),
+        RecommendedPack(name='croissance'),
+    ])
+    db.commit()
+    db.close()
+
+    yield
+    # Tear down the database
+    Base.metadata.drop_all(bind=engine)
+
+@pytest.fixture
+def client():
+    from infrastructure.database import SessionLocal
+    db = SessionLocal()
+    yield TestClient(app)
+    db.close()
+
+@pytest.fixture(autouse=True)
+def clean_db_before_each_test():
+    from infrastructure.database import SessionLocal
+    db = SessionLocal()
+    db.query(LeadPosition).delete()
+    db.query(LeadConcern).delete()
+    db.query(Lead).delete()
+    db.query(Contact).delete()
+    db.query(Company).delete()
+    db.query(Position).delete()
+    db.query(Concern).delete()
+    db.commit()
+    db.close()

--- a/tests/test_apibase.py
+++ b/tests/test_apibase.py
@@ -10,82 +10,9 @@ import json
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from infrastructure.web.app import app, get_current_user
-from infrastructure.web.auth import oauth2_scheme, TokenData
-from domain.orm import Lead, Contact, Company, Position, Concern, LeadPosition, LeadConcern, LeadUrgency, LeadStatus, NoteReason
-
-# Override the OIDC dependency for testing
-async def override_get_current_user():
-    return TokenData(username="testuser")
-
-async def override_oauth2_scheme():
-    return "fake-token"
-
-app.dependency_overrides[get_current_user] = override_get_current_user
-app.dependency_overrides[oauth2_scheme] = override_oauth2_scheme
-
-@pytest.fixture(scope="session", autouse=True)
-def test_db():
-    from infrastructure.database import Base, engine, SessionLocal
-    from domain.orm import LeadStatus, LeadUrgency, RecommendedPack
-    # Set up the database
-    Base.metadata.create_all(bind=engine)
-
-    db = SessionLocal()
-
-    # Clean up enum tables before seeding
-    db.query(LeadStatus).delete()
-    db.query(LeadUrgency).delete()
-    db.query(RecommendedPack).delete()
-    db.query(NoteReason).delete()
-    db.commit()
-
-    # Seed enum tables
-    db.add_all([
-        NoteReason(name='appel sortant'),
-        NoteReason(name='mail sortant'),
-        NoteReason(name='appel entrant'),
-        NoteReason(name='mail entrant'),
-        NoteReason(name='rencontre'),
-        LeadStatus(name='nouveau'),
-        LeadStatus(name='à rappeler'),
-        LeadStatus(name='relancé'),
-        LeadStatus(name='proposition envoyée'),
-        LeadStatus(name='gagné'),
-        LeadStatus(name='perdu'),
-        LeadUrgency(name='immédiat'),
-        LeadUrgency(name='ce mois'),
-        LeadUrgency(name='moyen terme'),
-        RecommendedPack(name='conformité'),
-        RecommendedPack(name='confiance'),
-        RecommendedPack(name='croissance'),
-    ])
-    db.commit()
-    db.close()
-
-    yield
-    # Tear down the database
-    Base.metadata.drop_all(bind=engine)
-
-@pytest.fixture
-def client():
-    from infrastructure.database import SessionLocal
-    db = SessionLocal()
-    yield TestClient(app)
-    db.close()
-
-@pytest.fixture(autouse=True)
-def clean_db_before_each_test():
-    from infrastructure.database import SessionLocal
-    db = SessionLocal()
-    db.query(LeadPosition).delete()
-    db.query(LeadConcern).delete()
-    db.query(Lead).delete()
-    db.query(Contact).delete()
-    db.query(Company).delete()
-    db.query(Position).delete()
-    db.query(Concern).delete()
-    db.commit()
-    db.close()
+from infrastructure.web.auth import oauth2_scheme
+from domain.orm import Lead, Contact, Company, Position, Concern, LeadPosition, LeadConcern, LeadUrgency, LeadStatus
+from tests.conftest import override_get_current_user, override_oauth2_scheme
 
 def get_altcha_payload(client):
     challenge_response = client.get('/altcha-challenge/')

--- a/tests/test_lead_service.py
+++ b/tests/test_lead_service.py
@@ -1,0 +1,122 @@
+import pytest
+from unittest.mock import patch
+from domain.orm import Lead, LeadModificationLog, Fingerprint
+from application.contact_service import LeadService
+from domain.contact import LeadUpdateRequest, LeadPayload
+from infrastructure.database import SessionLocal
+
+@pytest.fixture
+def lead_service():
+    db = SessionLocal()
+    yield LeadService(db)
+    db.close()
+
+def test_create_lead_with_fingerprint_and_altcha(lead_service, client):
+    # First, create a fingerprint
+    fingerprint_data = {
+        "visitorId": "test-visitor-id",
+        "components": {"test": "data"}
+    }
+    fingerprint = Fingerprint(**fingerprint_data)
+    db = SessionLocal()
+    db.add(fingerprint)
+    db.commit()
+    db.close()
+
+    lead_payload = LeadPayload(
+        name="Test Lead",
+        email="test@example.com",
+        company_name="Test Company",
+        positions=["Developer"],
+        concerns=["PSSI"],
+        urgency="ce mois",
+        conscent=True
+    )
+    altcha_solution = "test-altcha-solution"
+    visitor_id = "test-visitor-id"
+
+    lead = lead_service.create_lead(lead_payload, altcha_solution, visitor_id)
+
+    assert lead is not None
+    assert lead.altcha_solution == altcha_solution
+    assert lead.fingerprint_visitor_id == visitor_id
+
+def test_update_lead_success(lead_service, client):
+    # First, create a lead with a fingerprint and altcha
+    fingerprint_data = {
+        "visitorId": "test-visitor-id-update",
+        "components": {"test": "data"}
+    }
+    fingerprint = Fingerprint(**fingerprint_data)
+    db = SessionLocal()
+    db.add(fingerprint)
+    db.commit()
+
+    lead_payload = LeadPayload(
+        name="Test Lead",
+        email="test-update@example.com",
+        company_name="Test Company",
+        positions=["Developer"],
+        concerns=["PSSI"],
+        urgency="ce mois",
+        conscent=True
+    )
+    altcha_solution = "test-altcha-solution-update"
+    visitor_id = "test-visitor-id-update"
+    lead = lead_service.create_lead(lead_payload, altcha_solution, visitor_id)
+    db.close()
+
+    # Now, update the lead
+    update_data = LeadUpdateRequest(
+        name="Updated Lead Name",
+        altcha=altcha_solution,
+        visitorId=visitor_id
+    )
+    updated_lead = lead_service.update_lead(lead.id, update_data)
+
+    assert updated_lead is not None
+    assert updated_lead.contact.name == "Updated Lead Name"
+
+    # Check that the change was logged
+    db = SessionLocal()
+    log_entry = db.query(LeadModificationLog).filter_by(lead_id=lead.id).first()
+    assert log_entry is not None
+    assert log_entry.field_name == "name"
+    assert log_entry.old_value == "Test Lead"
+    assert log_entry.new_value == "Updated Lead Name"
+    db.close()
+
+def test_update_lead_invalid_fingerprint(lead_service, client):
+    # First, create a lead with a fingerprint and altcha
+    fingerprint_data = {
+        "visitorId": "test-visitor-id-invalid",
+        "components": {"test": "data"}
+    }
+    fingerprint = Fingerprint(**fingerprint_data)
+    db = SessionLocal()
+    db.add(fingerprint)
+    db.commit()
+
+    lead_payload = LeadPayload(
+        name="Test Lead",
+        email="test-invalid@example.com",
+        company_name="Test Company",
+        positions=["Developer"],
+        concerns=["PSSI"],
+        urgency="ce mois",
+        conscent=True
+    )
+    altcha_solution = "test-altcha-solution-invalid"
+    visitor_id = "test-visitor-id-invalid"
+    lead = lead_service.create_lead(lead_payload, altcha_solution, visitor_id)
+    db.close()
+
+    # Now, try to update the lead with an invalid fingerprint
+    update_data = LeadUpdateRequest(
+        name="Updated Lead Name",
+        altcha=altcha_solution,
+        visitorId="invalid-visitor-id"
+    )
+
+    with pytest.raises(ValueError, match="Fingerprint or Altcha solution does not match."):
+        lead_service.update_lead(lead.id, update_data)


### PR DESCRIPTION
This commit introduces a new `PUT /lead/{lead_id}` route to allow modification of an existing lead.

The changes include:
- A new `PUT /lead/{lead_id}` endpoint in `infrastructure/web/app.py`.
- An `update_lead` method in `application/contact_service.py` to handle the business logic of updating a lead.
- The `update_lead` method verifies the lead's creator using a fingerprint and Altcha solution.
- All modifications to a lead are logged in a new `lead_modification_logs` table.
- New Alembic migrations to update the database schema.
- New Pydantic models for the update request.
- New tests to verify the update functionality.